### PR TITLE
Update yaml requirement to 2.8|3.0 so it is not in conflict with robmorgan/phinx

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.4.16",
         "cakephp/cakephp": "~3.0",
-        "symfony/yaml": "~2.6"
+        "symfony/yaml": "~2.8|~3.0"
     },
     "authors": [
         {


### PR DESCRIPTION
When I tried to install your plugin with `composer require btaens/cakephp-hier-auth` it gave me conclusion: remove symfony/yaml v3.0.1 which is required by robmorgan/phinx, the lib used by cakephp. I think you need to update your composer.json file with new version of yaml. 

Also you should release tag or update your readme to `composer require btaens/cakephp-hier-auth:dev-master`
